### PR TITLE
Relaxing restrictions input `shelephant cp`

### DIFF
--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1005,12 +1005,17 @@ class Test_dataset(unittest.TestCase):
                 shutil.copytree("../dataset/.shelephant", ".shelephant", symlinks=True)
                 shelephant.dataset.lock(["source2"])
                 shelephant.dataset.update(["--quiet"])
-                shutil.copy2(
-                    ".shelephant/storage/source2.yaml",
-                    "../dataset/.shelephant/storage/source2.yaml",
-                )
 
             with cwd(dataset):
+                shelephant.dataset.cp(
+                    [
+                        "-f",
+                        "-q",
+                        "source2",
+                        "here",
+                        os.path.join(".shelephant", "storage", "source2.yaml"),
+                    ]
+                )
                 shelephant.dataset.update(["--quiet"])
 
             with cwd(dataset), contextlib.redirect_stdout(io.StringIO()) as sio:


### PR DESCRIPTION
Fixes https://github.com/tdegeus/shelephant/issues/173 : one can now ` shelephant cp remote here .shelephant/storage/remote.yaml`

Fixes https://github.com/tdegeus/shelephant/issues/134 : all paths are now considered for copying, regardless if they are in the database of the source