### PR TITLE
Allow copy of dataset files

### DIFF
--- a/docs/dataset.rst
+++ b/docs/dataset.rst
@@ -523,27 +523,13 @@ You can also update the database of a storage location on the storage location i
 This is useful to speedup updating a large database on a remote host, or for example if you have limited connectivity to a remote host or if you want to close the connection while computing checksums.
 The simplest you can do is:
 
-1.  Add to ``.shelephant/storage/here.yaml``
-
-    .. code-block:: yaml
-
-        search:
-        - rglob: '*.yaml'
-          root: .shelephant
-
-2.  Run
-
-    .. code-block:: bash
-
-        shelephant update here
-
-3.  Copy the database entry of a storage location:
+1.  Copy the database entry of a storage location:
 
     .. code-block:: bash
 
         shelephant cp here remote .shelephant/storage/remote.yaml
 
-4.  **On the storage location:**
+2.  **On the storage location:**
 
     a.  Run
 
@@ -557,7 +543,7 @@ The simplest you can do is:
 
             shelephant update
 
-5.  Receive the updates (from the dataset root):
+3.  Receive the updates (from the dataset root):
 
     .. code-block:: bash
 

--- a/docs/dataset.rst
+++ b/docs/dataset.rst
@@ -516,6 +516,54 @@ For the latter do
 This will create the symbolic links to the relevant locations in ``/local/mount``, but it will compute the checksums directly on the remote host.
 The additional benefit is that if the mount is unavailable, the behaviour is the same as for any SSH host.
 
+Updates on remote
+-----------------
+
+You can also update the database of a storage location on the storage location itself.
+This is useful to speedup updating a large database on a remote host, or for example if you have limited connectivity to a remote host or if you want to close the connection while computing checksums.
+The simplest you can do is:
+
+1.  Add to ``.shelephant/storage/here.yaml``
+
+    .. code-block:: yaml
+
+        search:
+        - rglob: '*.yaml'
+          root: .shelephant
+
+2.  Run
+
+    .. code-block:: bash
+
+        shelephant update here
+
+3.  Copy the database entry of a storage location:
+
+    .. code-block:: bash
+
+        shelephant cp here remote .shelephant/storage/remote.yaml
+
+4.  **On the storage location:**
+
+    a.  Run
+
+        .. code-block:: bash
+
+            shelephant lock remote
+
+    b.  Run (whenever you need):
+
+        .. code-block:: bash
+
+            shelephant update
+
+5.  Receive the updates (from the dataset root):
+
+    .. code-block:: bash
+
+        shelephant cp remote here .shelephant/storage/remote.yaml
+        shelephant update
+
 Updates with git
 ----------------
 

--- a/docs/dataset.rst
+++ b/docs/dataset.rst
@@ -94,7 +94,7 @@ This will:
                 - rglob: '*.h5'
                   skip: ['\..*, 'bak.*']
                 - rglob: '*.yaml'
-                  skip: ['\..*, 'bak.*', 'shelephant.*']
+                  skip: ['\..*, 'bak.*', '[\.]?(shelephant)(.*)']
 
     .. note::
 
@@ -527,7 +527,12 @@ The simplest you can do is:
 
     .. code-block:: bash
 
-        shelephant cp here remote .shelephant/storage/remote.yaml
+        shelephant cp here remote -ex .shelephant/storage/remote.yaml
+
+    .. note::
+
+        -   ``-e`` (``--exists``) is needed if ``.shelephant/storage/remote.yaml`` is not part of the dataset (recommended).
+        -   ``-x`` (``--no-update``) if then needed to prevent ``.shelephant/storage/remote.yaml`` being added to the dataset (recommended).
 
 2.  **On the storage location:**
 
@@ -547,7 +552,7 @@ The simplest you can do is:
 
     .. code-block:: bash
 
-        shelephant cp remote here .shelephant/storage/remote.yaml
+        shelephant cp remote here -ex .shelephant/storage/remote.yaml
         shelephant update
 
 Updates with git

--- a/docs/python.rst
+++ b/docs/python.rst
@@ -107,6 +107,18 @@ Details
 .. automodule:: shelephant
     :members:
 
+cli
+:::
+
+.. automodule:: shelephant.cli
+    :members:
+
+compute_hash
+::::::::::::
+
+.. automodule:: shelephant.compute_hash
+    :members:
+
 convert
 :::::::
 
@@ -117,12 +129,6 @@ dataset
 :::::::
 
 .. autoclass:: shelephant.dataset.Location
-    :members:
-
-info
-::::
-
-.. automodule:: shelephant.info
     :members:
 
 local

--- a/shelephant/cli.py
+++ b/shelephant/cli.py
@@ -258,6 +258,11 @@ def shelephant_cp(args: list[str], paths: list[str] = None):
     """
     Command-line tool, see ``--help``.
 
+    :param args: Command-line arguments (should be all strings).
+    :param paths:
+        Instead of reading ``files`` from the source YAML-file, specify a list of paths to copy.
+
+
     .. note::
 
         For input from dataset (``paths is not None``) the storage locations can have a prefix.
@@ -295,9 +300,6 @@ def shelephant_cp(args: list[str], paths: list[str] = None):
                 destpath="/path/to/root/of/source1/bar",
                 files=["a.txt", "b.txt"],
             )
-
-    :param args: Command-line arguments (should be all strings).
-    :param paths: Paths to copy (if not given, all files in source are copied).
     """
 
     parser = _shelephant_cp_parser()

--- a/shelephant/cli.py
+++ b/shelephant/cli.py
@@ -254,14 +254,16 @@ def _shelephant_cp_parser():
     return parser
 
 
-def shelephant_cp(args: list[str], paths: list[str] = None):
+def shelephant_cp(args: list[str], paths: list[str] = None, force_paths: list[str] = None):
     """
     Command-line tool, see ``--help``.
 
     :param args: Command-line arguments (should be all strings).
     :param paths:
         Instead of reading ``files`` from the source YAML-file, specify a list of paths to copy.
-
+        Paths that are not in ``files`` of the YAML-file are ignored.
+    :param force_paths:
+        Add paths to copy even if they are not in ``files`` of the YAML-file.
 
     .. note::
 
@@ -325,16 +327,23 @@ def shelephant_cp(args: list[str], paths: list[str] = None):
     sourcepath = source.hostpath
     destpath = dest.hostpath
     paths = [] if paths is None else paths
+    force_paths = [] if force_paths is None else force_paths
 
     if suffix_source != pathlib.Path(""):
         files = [os.path.relpath(p, suffix_source) for p in files]
 
-    if len(paths) > 0:
+    if len(paths) > 0 or len(force_paths) > 0:
         if (common_prefix / deepest) != pathlib.Path(""):
             strip = common_prefix / deepest
             paths = [os.path.relpath(p, strip) for p in paths]
+            force_paths = [os.path.relpath(p, strip) for p in force_paths]
             assert not any(p.startswith("..") for p in paths), "Paths not in tree."
-        files = np.intersect1d(files, paths)
+            assert not any(p.startswith("..") for p in force_paths), "Paths not in tree."
+        if len(paths) > 0:
+            files = np.intersect1d(files, paths)
+        else:
+            files = []
+        files = np.union1d(files, force_paths)
 
     if source.ssh is not None or dest.ssh is not None:
         assert "rsync" in args.mode, "'rsync' required for ssh."

--- a/shelephant/cli.py
+++ b/shelephant/cli.py
@@ -242,7 +242,7 @@ def _shelephant_cp_parser():
     parser.add_argument(
         "--mode",
         type=str,
-        help="Use 'sha256', 'rsync', and/or 'basic'.",
+        help="Use 'sha256', 'rsync', and/or 'basic' to compare files.",
         default="sha256,rsync" if shutil.which("rsync") is not None else "sha256,basic",
     )
     parser.add_argument("-f", "--force", action="store_true", help="Overwrite without prompt.")
@@ -264,7 +264,9 @@ def shelephant_cp(args: list[str], paths: list[str] = None, filter_paths: bool =
 
     :param filter_paths:
         If ``True``, ``paths`` that are not in ``files`` of the YAML-file are ignored.
-        Otherwise all ``paths`` are copied.
+        If ``False`` all ``paths`` are copied: requires ``paths`` to exist on the source.
+
+    :return: List of changed files.
 
     .. note::
 

--- a/shelephant/dataset.py
+++ b/shelephant/dataset.py
@@ -882,9 +882,9 @@ def lock(args: list[str]):
     parser = _lock_parser()
     args = parser.parse_args(args)
     sdir = _search_upwards_dir(".shelephant")
+    assert sdir is not None, "Not a shelephant dataset"
     assert args.name.lower() != "here", "cannot lock 'here'"
-    if (sdir / "lock.txt").is_file():
-        assert args.name in yaml.read(sdir / "storage.yaml"), f"storage location unknown"
+    assert (sdir / "storage" / f"{args.name}.yaml").is_file(), "storage location not found"
     (sdir / "lock.txt").write_text(args.name)
 
 

--- a/shelephant/dataset.py
+++ b/shelephant/dataset.py
@@ -459,7 +459,6 @@ class Location:
 
         :param paths: List of paths to remove.
         """
-
         _, i, _ = np.intersect1d(
             self._files, np.unique(list(map(str, paths))), return_indices=True, assume_unique=True
         )
@@ -471,7 +470,6 @@ class Location:
         """
         See :meth:`read`.
         """
-
         if self.dump is None and self.search is None:
             return self
 
@@ -826,6 +824,7 @@ def _init_parser():
         pass
 
     parser = argparse.ArgumentParser(formatter_class=MyFmt, description=desc)
+    parser.add_argument("--database", action="store_true", help="Add search for database in 'here'")
     parser.add_argument("--version", action="version", version=version)
     return parser
 
@@ -847,7 +846,21 @@ def init(args: list[str]):
     (sdir / "unavailable").symlink_to("dead-link")
     (sdir / "symlinks.yaml").write_text("")
     yaml.dump(sdir / "storage.yaml", ["here"])
-    yaml.dump(sdir / "storage" / "here.yaml", {"root": "../.."})
+    opts = {"root": "../.."}
+    if args.database:
+        opts["search"] = [
+            {
+                "rglob": "*.yaml",
+                "root": ".shelephant",
+                "skip": ["(\\.shelephant)([\\/])(lock\\.txt)"],
+            }
+        ]
+        opts["files"] = [
+            ".shelephant/storage.yaml",
+            ".shelephant/here.yaml",
+            ".shelephant/symlinks.yaml",
+        ]
+    yaml.dump(sdir / "storage" / "here.yaml", opts)
 
 
 def _lock_parser():
@@ -884,7 +897,11 @@ def lock(args: list[str]):
     parser = _lock_parser()
     args = parser.parse_args(args)
     sdir = pathlib.Path(".shelephant")
-    assert args.name in yaml.read(sdir / "storage.yaml"), f"storage location '{args.name}' unknown"
+    assert args.name.lower() != "here", "cannot lock 'here'"
+    if (sdir / "lock.txt").is_file():
+        assert args.name in yaml.read(
+            sdir / "storage.yaml"
+        ), f"storage location '{args.name}' unknown"
     (sdir / "lock.txt").write_text(args.name)
 
 
@@ -1001,6 +1018,7 @@ def add(args: list[str]):
             else:
                 pathlib.Path(f"data/{args.name}").symlink_to(pathlib.Path("..") / "unavailable")
 
+        update(["here"])
         opts = [args.name]
         if args.shallow:
             opts.append("--shallow")
@@ -1128,27 +1146,29 @@ def update(args: list[str]):
     else:
         assert lock is None, "cannot update all locations from storage location"
         assert args.name in yaml.read(sdir / "storage.yaml"), f"'{args.name}' is not a location"
-        assert args.name != "here" or paths is None, "cannot specify paths for 'here'"
         args.name = [args.name]
 
     if lock is not None:
+        assert lock != "here"
         args.name = [lock]
 
     with search.cwd(sdir):
-        symlinks = yaml.read("symlinks.yaml", [])
-        symlinks = {pathlib.Path(i["path"]): pathlib.Path(i["storage"]) for i in symlinks}
+        # read existing symlinks
 
-        if args.clean:
-            with search.cwd(base):
-                for path in list(symlinks.keys()):
-                    if not path.is_symlink():
-                        symlinks.pop(path)
+        if lock is None:
+            symlinks = yaml.read("symlinks.yaml", [])
+            symlinks = {pathlib.Path(i["path"]): pathlib.Path(i["storage"]) for i in symlinks}
+            if args.clean:
+                with search.cwd(base):
+                    for path in list(symlinks.keys()):
+                        if not path.is_symlink():
+                            symlinks.pop(path)
 
         # update files and info
 
         for name in args.name:
             # "here": search for files that are not managed by shelephant
-            if name == "here" and paths is None:
+            if name == "here":
                 f = "storage/here.yaml"
                 Location.from_yaml(f).read().remove(list(symlinks.keys())).to_yaml(f, force=True)
                 continue
@@ -1241,6 +1261,10 @@ def update(args: list[str]):
                 for f in loc.files(info=False):
                     if prefix / pathlib.Path(f) not in files:
                         files[prefix / pathlib.Path(f)] = pathlib.Path("data") / name
+        # - remove database files
+        files.pop(pathlib.Path(".shelephant") / "symlinks.yaml", None)
+        for name in storage + ["here"]:
+            files.pop(pathlib.Path(".shelephant") / "storage" / f"{name}.yaml", None)
 
         add_links = []
         rm_links = []
@@ -1338,7 +1362,6 @@ def cp(args: list[str]):
     sdir = _search_upwards_dir(".shelephant")
     assert sdir is not None, "Not a shelephant dataset"
     assert not (sdir / "lock.txt").exists(), "cannot remove location from storage location"
-    assert args.destination != "here", "Cannot copy to here."
     storage = yaml.read(sdir / "storage.yaml")
     assert args.source in storage, f"Unknown storage location {args.source}"
     assert args.destination in storage, f"Unknown storage location {args.destination}"
@@ -1612,6 +1635,7 @@ def _status_parser():
     parser.add_argument("--print0", action="store_true", help="Print list of files (no table).")
     parser.add_argument("-n", "--nout", type=int, help="Maximal number of output arguments.")
     parser.add_argument("--table", type=str, default="SINGLE_BORDER", help="Select print style.")
+    parser.add_argument("--database", action="store_true", help="Show files in '.shelephant'.")
     parser.add_argument(
         "--in-use", type=str, help="Select storage location in use (use 'none' for unavailable)."
     )
@@ -1662,6 +1686,8 @@ def status(args: list[str]):
         storage = yaml.read(sdir / "storage.yaml")
         storage.remove("here")
         extra = Location.from_yaml("storage/here.yaml").files(info=False)
+        if not args.database:
+            extra = [i for i in extra if not i.startswith(".shelephant")]
 
         sha = "x" * np.ones((len(symlinks), len(storage)), dtype=object)
         mtime = np.inf * np.ones(sha.shape, dtype=np.float64)
@@ -1710,7 +1736,7 @@ def status(args: list[str]):
 
     data = np.hstack((np.array([symlinks]).T, inuse.reshape(-1, 1), sha))
 
-    e = "x" * np.ones((len(extra), data.shape[1]), dtype=object)
+    e = "?" * np.ones((len(extra), data.shape[1]), dtype=object)
     e[:, 0] = extra
     e[:, 1] = "here"
     data = np.vstack((data, e))

--- a/shelephant/dataset.py
+++ b/shelephant/dataset.py
@@ -1128,6 +1128,7 @@ def update(args: list[str]):
     else:
         assert lock is None, "cannot update all locations from storage location"
         assert args.name in yaml.read(sdir / "storage.yaml"), f"'{args.name}' is not a location"
+        assert args.name != "here" or paths is None, "cannot specify paths for 'here'"
         args.name = [args.name]
 
     if lock is not None:

--- a/shelephant/search.py
+++ b/shelephant/search.py
@@ -58,36 +58,38 @@ def _check_skip(path: str, skip: list[str]) -> bool:
     return False
 
 
-def _search_rglob(rglob: str, skip: list[str] = []) -> list[pathlib.Path]:
+def _search_rglob(rglob: str, root: str = ".", skip: list[str] = []) -> list[pathlib.Path]:
     """
     Search for files using ``rglob``.
 
     :param rglob: The pattern to search for.
+    :param root: The root directory to search in.
     :param skip: A list of regex to skip.
     :return: A list of paths.
     """
     if isinstance(skip, str):
         skip = [skip]
     ret = []
-    for path in pathlib.Path(".").rglob(rglob):
+    for path in pathlib.Path(root).rglob(rglob):
         if _check_skip(str(path), skip):
             continue
         ret.append(path)
     return ret
 
 
-def _search_glob(glob: str, skip: list[str] = []) -> list[pathlib.Path]:
+def _search_glob(glob: str, root: str = ".", skip: list[str] = []) -> list[pathlib.Path]:
     """
     Search for files using ``glob``.
 
     :param glob: The pattern to search for.
+    :param root: The root directory to search in.
     :param skip: A list of regex to skip.
     :return: A list of paths.
     """
     if isinstance(skip, str):
         skip = [skip]
     ret = []
-    for path in pathlib.Path(".").glob(glob):
+    for path in pathlib.Path(root).glob(glob):
         if _check_skip(str(path), skip):
             continue
         ret.append(path)
@@ -138,7 +140,7 @@ def search(*settings: dict, root: pathlib.Path = pathlib.Path(".")) -> list[path
                 ret += _search_glob(**setting)
             else:
                 raise ValueError(f"Unknown search setting: {setting}")
-        return ret
+        return list(set(ret))
 
 
 if __name__ == "__main__":

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1007,7 +1007,7 @@ class Test_dataset(unittest.TestCase):
                         "-q",
                     ]
                 )
-                shelephant.dataset.cp(["-fq", "here", "source2", path])
+                shelephant.dataset.cp(["-ex", "-fq", "here", "source2", path])
 
             with cwd(source2):
                 s2 += create_dummy_files(["e.txt", "f.txt"], slice(6, None, None))
@@ -1016,7 +1016,7 @@ class Test_dataset(unittest.TestCase):
 
             with cwd(dataset):
                 path = os.path.join(".shelephant", "storage", "source2.yaml")
-                shelephant.dataset.cp(["-fq", "source2", "here", path])
+                shelephant.dataset.cp(["-ex", "-fq", "source2", "here", path])
                 shelephant.dataset.update(["--quiet"])
 
             with cwd(dataset), contextlib.redirect_stdout(io.StringIO()) as sio:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -994,7 +994,7 @@ class Test_dataset(unittest.TestCase):
 
             path = os.path.join(".shelephant", "storage", "source2.yaml")
             with cwd(dataset):
-                shelephant.dataset.init(["--database"])
+                shelephant.dataset.init([])
                 shelephant.dataset.add(["source1", "../source1", "--rglob", "*.txt", "-q"])
                 shelephant.dataset.add(
                     [
@@ -1002,10 +1002,8 @@ class Test_dataset(unittest.TestCase):
                         "../source2",
                         "--rglob",
                         "*.txt",
-                        "--rglob",
-                        "*.yaml",
                         "--skip",
-                        "(\\.shelephant)([\\/])(lock\\.txt)",
+                        r"[\.]?(shelephant)(.*)",
                         "-q",
                     ]
                 )


### PR DESCRIPTION
Fixes https://github.com/tdegeus/shelephant/issues/173 : `shelephant cp -ex here remote .shelephant/storage/remote.yaml`

Fixes https://github.com/tdegeus/shelephant/issues/134 : `shelephant cp -e a b ...` to force copy without consulting the database 

Closes https://github.com/tdegeus/shelephant/pull/175
Closes https://github.com/tdegeus/shelephant/pull/174